### PR TITLE
Fix displayText being set on miners

### DIFF
--- a/script/miner.js
+++ b/script/miner.js
@@ -79,6 +79,9 @@ class Miner extends Villager
         {
             image(ironImg, this.posX - 2, this.posY, 15, 15);
         }
+        fill(255);
+        textAlign(CENTER);
+        text(this.displayText, this.posX, this.posY - 20);
     }
 
     animate() {


### PR DESCRIPTION
Noticed while testing your PR (I wanted to see the miner / mine images), the miners displayText wasn't appearing correctly.

This should fix that, and it now shows `OUCH!` when near an enemy!

Happy Hacktoberfest!